### PR TITLE
Add default values to `calc`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ const aspectRatio = plugin(
         {
           [baseSelectors]: {
             position: 'relative',
-            paddingBottom: `calc(var(--tw-aspect-h) / var(--tw-aspect-w) * 100%)`,
+            paddingBottom: `calc(var(--tw-aspect-h, 1) / var(--tw-aspect-w, 1) * 100%)`,
           },
           [childSelectors]: {
             position: 'absolute',


### PR DESCRIPTION
this will allow the user to only specify the width, if they are doing an n:1 aspect ratio.

```html
<div class="aspect-w-1 aspect-h-1">...</div>
```

can be simplified to:

```html
<div class="aspect-w-1">...</div>
```