### PR TITLE
Remove comma-separated classes to work around @apply issue

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,34 +4,22 @@ const aspectRatio = plugin(
   function ({ addComponents, theme, variants, e }) {
     const values = theme('aspectRatio')
 
-    const baseSelectors = Object.entries(values)
-      .map(([key, value]) => {
-        return `.${e(`aspect-w-${key}`)}`
-      })
-      .join(',\n')
-
-    const childSelectors = Object.entries(values)
-      .map(([key, value]) => {
-        return `.${e(`aspect-w-${key}`)} > *`
-      })
-      .join(',\n')
-
     addComponents(
       [
+        Object.entries(values).map(([key]) => {
+          return {
+            [`.${e(`aspect-w-${key}`)} > *`]: {
+              position: 'absolute',
+              height: '100%',
+              width: '100%',
+              top: '0',
+              right: '0',
+              bottom: '0',
+              left: '0',
+            },
+          }
+        }),
         {
-          [baseSelectors]: {
-            position: 'relative',
-            paddingBottom: `calc(var(--tw-aspect-h) / var(--tw-aspect-w) * 100%)`,
-          },
-          [childSelectors]: {
-            position: 'absolute',
-            height: '100%',
-            width: '100%',
-            top: '0',
-            right: '0',
-            bottom: '0',
-            left: '0',
-          },
           '.aspect-none': {
             position: 'static',
             paddingBottom: '0',
@@ -49,6 +37,8 @@ const aspectRatio = plugin(
         Object.entries(values).map(([key, value]) => {
           return {
             [`.${e(`aspect-w-${key}`)}`]: {
+              position: 'relative',
+              paddingBottom: `calc(var(--tw-aspect-h) / var(--tw-aspect-w) * 100%)`,
               '--tw-aspect-w': value,
             },
           }


### PR DESCRIPTION
Fixes #2
References https://github.com/tailwindlabs/tailwindcss/issues/3360

There is an issue in tailwind with the way it applies `@apply` rules where the class it's trying to rewrite has been provided as one of a comma separated list of classes such as:

```
.aspect-w-14,
.aspect-w-15,
.aspect-w-16 {
  position: relative;
  padding-bottom: calc(var(--tw-aspect-h) / var(--tw-aspect-w) * 100%)
}
```

While this is pending a fix in TW, this avoids the issue by exploding out the classes in this plugin.

Given the input:
```
@tailwind components;

.sixteen-by-nine {
  @apply aspect-w-16 aspect-h-9;
}
```

The previous output was:
```
.sixteen-by-nine {
  --tw-aspect-w: 16;
  --tw-aspect-h: 9
}
```

With this change it is:
```
.sixteen-by-nine > * {
  position: absolute;
  height: 100%;
  width: 100%;
  top: 0;
  right: 0;
  bottom: 0;
  left: 0
}

.sixteen-by-nine {
  position: relative;
  padding-bottom: calc(var(--tw-aspect-h) / var(--tw-aspect-w) * 100%);
  --tw-aspect-w: 16;
  --tw-aspect-h: 9
}
```