### PR TITLE
mark tailwindcss as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
   "scripts": {
     "prepublishOnly": "node scripts/build.js"
   },
+   "peerDependencies": {
+    "tailwindcss": "^2.0.0"
+  },
   "devDependencies": {
     "autoprefixer": "10",
     "clean-css": "^4.2.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "prepublishOnly": "node scripts/build.js"
   },
    "peerDependencies": {
-    "tailwindcss": "^2.0.0"
+    "tailwindcss": ">=2.0.0"
   },
   "devDependencies": {
     "autoprefixer": "10",


### PR DESCRIPTION
This plugin uses tailwindcss internally, but marks it only as a dev dependency rather than a peer dependency, causing errors/undefined behavior in monorepos and Yarn PNP. Correctly adding tailwind as a peer dependency allows for correct resolution to occur while still referencing the *user's* tailwind and not an internal version.

Other official plugins have already corrected this: see tailwindlabs/tailwindcss-forms@8a8671b

This pull request is identical to https://github.com/tailwindlabs/tailwindcss-line-clamp/pull/6. Both other official plugins (forms, typography) already correctly use peer dependencies.