### PR TITLE
Fix release date in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Nothing yet!
 
-## [0.2.1] - 2020-05-24
+## [0.2.1] - 2021-05-24
 
 ### Fixed
 


### PR DESCRIPTION
2020 [has been an overly long year](https://calendar2020.noj.cc/), so it’s time to transition into the next year ⏭